### PR TITLE
修复弹幕在移动端卡顿

### DIFF
--- a/src/components/Barrage.vue
+++ b/src/components/Barrage.vue
@@ -94,8 +94,6 @@
       position: absolute;
       padding: 5px 0;
       white-space:nowrap;
-      transition: all 0.6s linear;
-      -webkit-transition: all 0.6s linear;
       span{
         padding: 0 15px;
         &.mine{


### PR DESCRIPTION
经测试p标签的transition会导致在移动端及safari下弹幕动画卡顿，去除该属性弹幕正常滚动