### PR TITLE
修复移动端点击输入框页面自动缩放

### DIFF
--- a/src/components/Invitation.vue
+++ b/src/components/Invitation.vue
@@ -156,6 +156,7 @@ export default {
                 border-bottom: 1px solid #f7debb;
                 color: #a9895d;
                 background: transparent;
+                font-size: 16px;
                 &::-webkit-input-placeholder { color: #E8D1B1;font-size: 12px; }
                 &::-moz-placeholder { color: #E8D1B1;font-size: 12px; }
                 &:-ms-input-placeholder { color: #E8D1B1;font-size: 12px; }


### PR DESCRIPTION
移动端点击输入框时页面会自动放大，导致后面的样式可能会出现问题，增加font-size: 16px可修复此问题